### PR TITLE
Fixes to embed Go files

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,11 +2,15 @@ package main
 
 import (
 	"context"
+	"embed"
 	"fmt"
 
 	"github.com/sqlc-dev/plugin-sdk-go/codegen"
 	"github.com/sqlc-dev/plugin-sdk-go/plugin"
 )
+
+//go:embed templates/*
+var templates embed.FS
 
 const (
 	generateFileName = "bulk.sql.go"

--- a/parser.go
+++ b/parser.go
@@ -5,13 +5,12 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"os"
 )
 
 // parseGoCode parses a Go source file and extracts the code of a specific function by its name.
 // It returns the function code as a byte slice or an error if the function is not found.
 func parseGoCode(sourceFile string, targetFuncName string) ([]byte, error) {
-	srcBytes, err := os.ReadFile(sourceFile)
+	srcBytes, err := templates.ReadFile(sourceFile)
 	if err != nil {
 		return nil, err
 	}

--- a/template.go
+++ b/template.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"embed"
 	"fmt"
 	"go/format"
 	"strconv"
@@ -13,9 +12,6 @@ import (
 
 	"github.com/sqlc-dev/plugin-sdk-go/sdk"
 )
-
-//go:embed templates/*
-var templates embed.FS
 
 func executeTemplate(
 	_ context.Context, templateName string, data any,


### PR DESCRIPTION
It is necessary to embed the Go file so that it can be used as a plugin.